### PR TITLE
Added support for discovery-swarm-webrtc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ typings/
 
 # next.js build output
 .next
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ class SubSignalhub {
   constructor(instance, prefix) {
     this._instance = instance
     this._prefix = prefix
+    this.app = instance.app + this._prefix;
   }
 
   subscribe(channel) {


### PR DESCRIPTION
Hi @RangerMauve again :smile: 

In the discovery-swarm-webrtc we use the `signal.app` to detect new signals, with sub-signalhub the app should be the original app + prefix (I think).

Do you think that is ok?